### PR TITLE
Fix inconsistant coloring on `advancements.cloudstorage.bloviator.title`

### DIFF
--- a/src/main/resources/assets/cloudstorage/lang/en_us.json
+++ b/src/main/resources/assets/cloudstorage/lang/en_us.json
@@ -74,7 +74,7 @@
   "advancements.cloudstorage.root.desc": "The sky is the limit",
   "advancements.cloudstorage.badloon.title": "Deflation",
   "advancements.cloudstorage.badloon.desc": "Pop a badloon before it pops you",
-  "advancements.cloudstorage.bloviator.title": "Sky of §mBeginning§r Annoying",
+  "advancements.cloudstorage.bloviator.title": "Sky of §mBeginning§r§a Annoying",
   "advancements.cloudstorage.bloviator.desc": "Slay a bloviator lest you fall to your demise",
   "advancements.cloudstorage.balloon.title": "Unpoppable",
   "advancements.cloudstorage.balloon.desc": "Craft a balloon from balloon pieces and string",


### PR DESCRIPTION
For the achievement `Sky of Beginning Annoying`, a reset is called to stop striking through the text, but due to this reset the text following the rest is default white instead of green.
![image](https://user-images.githubusercontent.com/41973452/198859129-5044eb3f-251f-4113-b591-9324da106884.png)


This PR attempts to resolve the issue by just setting green directly after the reset, but I have NOT tested if this actually works.

Also I did this with github webeditor so they forced me to add a newline to this file 🙃 